### PR TITLE
Don't autorun all tests on start and after pass

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -5,7 +5,7 @@ guard 'bundler' do
   watch('Gemfile')
 end
 
-guard 'rspec', :version => 2 do
+guard 'rspec', :version => 2, :all_after_pass => false, :all_on_start => false do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec/" }
@@ -23,7 +23,7 @@ guard 'rspec', :version => 2 do
   watch(%r{^app/views/(.+)/.*\.(erb|haml)$})          { |m| "spec/requests/#{m[1]}_spec.rb" }
 end
 
-guard 'cucumber' do
+guard 'cucumber', :all_after_pass => false, :all_on_start => false do
   watch(%r{^features/.+\.feature$})
   watch(%r{^features/support/.+$})          { 'features' }
   watch(%r{^features/step_definitions/(.+)_steps\.rb$}) { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'features' }


### PR DESCRIPTION
If you want to run all tests you can manually instruct Guard to do so. This allows for greater control over when tests are run.
