### PR TITLE
Fix multiple purchases payout

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -102,9 +102,9 @@ class PurchasesController < ApplicationController
 
   def confirmed
     authorize! :manage, Purchase
-    @purchases = Purchase.confirmed
-    @purchases = @purchases.group_by{|p| p.person }.map{|k, v| {k => v.sum(&:total)} }
-    @purchases = @purchases.inject({}){|s, h| s.merge(h)}
+
+    @purchases = Purchase.payable_grouped_by_person
+    
     respond_to do |format|
       format.html # index.html.erb
       format.xml  { render :xml => @purchases }
@@ -113,11 +113,11 @@ class PurchasesController < ApplicationController
 
   def pay_multiple
     authorize! :manage, Purchase
-    people_ids = params[:pay].keep_if {|k,v| v.to_i == 1 }.keys
-    @purchases = Purchase.confirmed.where(:person_id => people_ids)
-    @purchases.each{|p| p.pay! }
+    
+    purchase_ids = Purchase.pay_multiple!(params)
+    
     respond_to do |format|
-      format.html { redirect_to(confirmed_purchases_path, :notice => "Betalda (#{@purchases.map(&:id)})!") }
+      format.html { redirect_to(confirmed_purchases_path, :notice => "Betalda (#{purchase_ids})!") }
     end
   end
 

--- a/app/views/purchases/confirmed.html.haml
+++ b/app/views/purchases/confirmed.html.haml
@@ -18,4 +18,5 @@
           %td
             = check_box_tag "pay[#{person.id}]"
             = label_tag "pay[#{person.id}]", "Betala"
-  = submit_tag
+
+  = submit_tag "Betala!", class: 'btn btn-primary'

--- a/app/views/purchases/confirmed.html.haml
+++ b/app/views/purchases/confirmed.html.haml
@@ -1,7 +1,7 @@
 %h1 Bekräftade inköp
 
 = form_tag pay_multiple_purchases_path, :method => :put do
-  %table.datatable
+  %table.datatable.table.table-striped
     %thead
       %tr
         %th Person

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110809094208) do
+ActiveRecord::Schema.define(:version => 20110909142954) do
 
   create_table "budget_posts", :force => true do |t|
     t.integer "business_unit_id",        :null => false

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -134,4 +134,19 @@ describe PurchasesController do
     end
   end
 
+  describe "GET confirmed" do
+    it "calls only fetches payable purchases" do
+      Purchase.should_receive(:payable_grouped_by_person).and_return([])
+
+      get :confirmed
+    end
+  end
+
+  describe "POST pay_multiple" do
+    it "only fetches payable purchases" do
+      Purchase.should_receive(:payable).and_return([])
+
+      post :pay_multiple,  :pay => {}
+    end
+  end
 end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -169,4 +169,46 @@ describe Purchase do
     @purchase.slug.should_not be_blank
     @purchase.slug.should =~ /-#{@purchase.id}$/
   end
+
+  describe ".payable" do
+    before(:all) do
+      stub_request(:post, "http://localhost:8981/solr/update?wt=ruby").to_return(:status => 200, :body => "", :headers => {})
+      @purchases = {
+        :new => Factory(:purchase),
+        :confirmed => Factory(:purchase, :workflow_state => 'confirmed'),
+        :edited => Factory(:purchase, :workflow_state => 'edited'),
+        :bookkept => Factory(:purchase, :workflow_state => 'bookkept'),
+        :paid => Factory(:purchase, :workflow_state => 'paid'),
+        :finalized => Factory(:purchase)
+      }
+
+      @purchases[:finalized].update_attribute(:workflow_state, 'finalized')
+
+    end
+
+    %w[confirmed bookkept].each do |state|
+      it "should include #{state} purchase" do
+        Purchase.payable.should include(@purchases[state.to_sym])
+      end
+    end
+
+    %w[new edited paid finalized].each do |state|
+      it "should include #{state} purchase" do
+        Purchase.payable.should_not include(@purchases[state.to_sym])
+      end
+    end
+
+    after(:all) do
+      stub_request(:post, "http://localhost:8981/solr/update?wt=ruby").to_return(:status => 200, :body => "", :headers => {})
+      @purchases.values.map(&:destroy)
+    end
+  end
+
+  describe ".payable_grouped_by_person" do
+    pending("write some tests")
+  end
+
+  describe ".pay_payable_by!" do
+    pending("write some tests")
+  end
 end


### PR DESCRIPTION
Lagt till `Purchase.payable` som bara inkluderar inköp som går att markera som betalda just nu.

Även ändrat så att purchases/confirmed och purchases/pay_multiple använder denna, genom att anropa två klassmetoder på Purchase (jag lyfte ut logiken ur controllern).

Detta borde fixa #89 och #91.
