### PR TITLE
Replace CoverMe with SimpleCov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ config/local.yml
 public/stylesheets/compiled
 tags
 *.swp
-coverage.data
 config/exceptional.yml
 public/stylesheets/*
 solr/data/

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ end
 # Gems for test environment
 group :test do
   gem 'capybara'
-  gem 'cover_me'
   gem 'cucumber-rails'
   gem 'database_cleaner'
   gem 'factory_girl_rails'
@@ -55,5 +54,6 @@ group :test do
   gem 'rspec-rails'
   gem 'selenium'
   gem 'shoulda-matchers'
+  gem 'simplecov', '~> 0.9', require: false
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,11 +70,6 @@ GEM
     cocoon (1.0.14)
     coderay (1.0.7)
     commonjs (0.2.5)
-    configatron (2.8.3)
-      yamler (>= 0.1.0)
-    cover_me (1.2.0)
-      configatron
-      hashie
     crack (0.3.1)
     cucumber (1.1.0)
       builder (>= 2.1.2)
@@ -93,6 +88,7 @@ GEM
       orm_adapter (~> 0.0.3)
       warden (~> 1.0.3)
     diff-lcs (1.1.3)
+    docile (1.1.5)
     erubis (2.7.0)
     escape (0.0.4)
     execjs (1.2.6)
@@ -118,7 +114,6 @@ GEM
       activesupport (>= 3.1, < 4.1)
       haml (>= 3.1, < 4.1)
       railties (>= 3.1, < 4.1)
-    hashie (1.2.0)
     headless (0.2.2)
     hike (1.2.3)
     i18n (0.6.11)
@@ -237,6 +232,11 @@ GEM
     shoulda-matchers (1.0.0)
     simple-navigation (3.5.0)
       activesupport (>= 2.3.2)
+    simplecov (0.9.1)
+      docile (~> 1.1.0)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
     slop (3.3.2)
     sprockets (2.2.2)
       hike (~> 1.2)
@@ -279,7 +279,6 @@ GEM
     workflow (0.8.1)
     xpath (0.1.4)
       nokogiri (~> 1.3)
-    yamler (0.1.0)
     zip (2.0.2)
 
 PLATFORMS
@@ -292,7 +291,6 @@ DEPENDENCIES
   capybara
   chosen_rails
   cocoon
-  cover_me
   cucumber-rails
   database_cleaner
   decent_exposure
@@ -325,6 +323,7 @@ DEPENDENCIES
   selenium
   shoulda-matchers
   simple-navigation
+  simplecov (~> 0.9)
   sunspot_rails
   sunspot_solr
   uglifier

--- a/README.md
+++ b/README.md
@@ -39,3 +39,10 @@ replacing KTHID with your KTH username, like `koronen`.
 
 Insert your ugid into config/local.yml in order to get the controller specs to
 work properly (otherwise the test code can't log in).
+
+### Test coverage
+
+To generate coverage data, set the environment variable `COVERAGE` before
+running the test.
+
+    COVERAGE=1 bundle exec rake

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,12 @@
 # This file is copied to ~/spec when you run 'ruby script/generate rspec'
 # from the project root directory.
 ENV['RAILS_ENV'] ||= 'test'
-require 'cover_me'
+
+if ENV['COVERAGE']
+  require 'simplecov'
+  SimpleCov.start 'rails'
+end
+
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'


### PR DESCRIPTION
`cover_me` has not been updated since 2011 and fails randomly on Travis CI. `simplecov` is actively maintained and known to work.
