### PR TITLE
Rspec fixups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ end
 # Gems for test environment
 group :test do
   gem 'capybara'
-  gem 'cucumber-rails'
+  gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'factory_girl_rails'
   gem 'headless'

--- a/spec/controllers/budget_controller_spec.rb
+++ b/spec/controllers/budget_controller_spec.rb
@@ -19,7 +19,7 @@ describe BudgetController do
     describe 'show' do
       it "assigns the selected year's budget_rows as @budget_rows" do
         rows = [mock_model(BudgetRow), mock_model(BudgetRow)]
-        BudgetRow.stub!(:year).and_return { rows }
+        BudgetRow.stub(:year).and_return { rows }
         get :show, id: @year
         assigns(:budget_rows).should eq rows
       end
@@ -28,7 +28,7 @@ describe BudgetController do
     describe 'edit' do
       it "assigns the selected year's budget_rows as @budget_rows" do
         rows = [mock_model(BudgetRow), mock_model(BudgetRow)]
-        BudgetRow.stub!(:year).and_return { rows }
+        BudgetRow.stub(:year).and_return { rows }
         get :show, id: @year
         assigns(:budget_rows).should eq rows
       end

--- a/spec/models/budget_row_spec.rb
+++ b/spec/models/budget_row_spec.rb
@@ -4,7 +4,7 @@ describe BudgetRow do
   describe '#total' do
     let(:person) { Factory :person }
 
-    before(:all) do
+    before(:each) do
       PaperTrail.whodunnit = person.id
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ end
 
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
-require 'rspec/autorun'
 require 'controller_macros'
 require 'formtastic'
 require 'headless'


### PR DESCRIPTION
- Replace deprecated `stub!` with `stub`
- Don't call `subject` from a `before(:all)` block
