### PR TITLE
Tidy up budget controller

### DIFF
--- a/app/controllers/budget_controller.rb
+++ b/app/controllers/budget_controller.rb
@@ -17,11 +17,8 @@ class BudgetController < ApplicationController
 
   def update
     ActiveRecord::Base.transaction do
-      rows = params[:budget_rows]
-      posts = params[:budget_posts]
-
-      rows = BudgetRow.update(rows.keys, rows.values)
-      posts = BudgetPost.update(posts.keys, posts.values)
+      rows = update_multiple(:budget_rows)
+      posts = update_multiple(:budget_posts)
 
       if [rows, posts].flatten.any?(&:invalid?)
         fail ActiveRecord::Rollback
@@ -38,5 +35,11 @@ class BudgetController < ApplicationController
 
   def get_or_set_year
     @year = params[:id] || Time.now.year
+  end
+
+  def update_multiple(key)
+    model = key.to_s.singularize.camelize.constantize
+    hash = params[key]
+    model.update(hash.keys, hash.values)
   end
 end

--- a/app/models/budget_row.rb
+++ b/app/models/budget_row.rb
@@ -4,6 +4,8 @@ class BudgetRow < ActiveRecord::Base
 
   scope :year, lambda { |year| includes(budget_post: :purchases).where(year: year) }
 
+  validates :sum, numericality: { greater_than_or_equal_to: 0 }
+
   def purchases
     budget_post.purchases.where(year: year)
   end

--- a/spec/models/budget_post_spec.rb
+++ b/spec/models/budget_post_spec.rb
@@ -25,5 +25,11 @@ describe BudgetPost do
     end
   end
 
+  it "is invalid without a mage_arrangemen_number" do
+    post = Factory :budget_post
+    post.mage_arrangement_number = nil
+    post.should be_invalid
+  end
+
   pending 'write some more specs'
 end

--- a/spec/models/budget_row_spec.rb
+++ b/spec/models/budget_row_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe BudgetRow do
+
+  it "is invalid if sum is negative" do
+    row = BudgetRow.new sum: -1
+    row.should be_invalid
+    row.errors.messages.keys.should include(:sum)
+  end
+
   describe '#total' do
     let(:person) { Factory :person }
 


### PR DESCRIPTION
I tidied up `BudgetController#update` to be less repetitive. However, this change also introduces a minor change in behavior:

If either a budget post or a budget row value sent to `BudgetController#update` fails, none of the changes will be made.
- `BudgetRow#sum` must not be negative
- DRY up `BudgetController#update`
- Tests for `BudgetController#update` rollbacks
- `BudgetPost#mage_arrangement_number` must exist
